### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -94,7 +94,7 @@ async function checkRepoBypassedRuleSuites(octokit, owner, repo, ref, mergeCommi
     try {
         // Validate owner and repo values
         const ownerPattern = /^[a-zA-Z0-9-]+$/;
-        const repoPattern = /^[a-zA-Z0-9-_]+$/;
+        const repoPattern = /^[a-zA-Z0-9_-]+$/;
         if (!ownerPattern.test(owner) || !repoPattern.test(repo)) {
             logger.error(`Invalid owner or repo value: owner=${owner}, repo=${repo}`);
             return [];

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -92,6 +92,14 @@ async function createOctokitClient() {
  */
 async function checkRepoBypassedRuleSuites(octokit, owner, repo, ref, mergeCommitSha) {
     try {
+        // Validate owner and repo values
+        const ownerPattern = /^[a-zA-Z0-9-]+$/;
+        const repoPattern = /^[a-zA-Z0-9-_]+$/;
+        if (!ownerPattern.test(owner) || !repoPattern.test(repo)) {
+            logger.error(`Invalid owner or repo value: owner=${owner}, repo=${repo}`);
+            return [];
+        }
+        
         const apiPath = `/repos/${owner}/${repo}/rulesets/rule-suites`;
         
         const params = {


### PR DESCRIPTION
Potential fix for [https://github.com/katiem0/github-pr-bypass-checker/security/code-scanning/1](https://github.com/katiem0/github-pr-bypass-checker/security/code-scanning/1)

To fix the SSRF vulnerability, we need to ensure that the `owner` and `repo` values are validated against a known list of allowed values or patterns before constructing the URL. This will prevent an attacker from injecting malicious values into the URL.

1. Create a list of allowed owners and repositories or define a pattern that valid GitHub repository identifiers must match.
2. Validate the `owner` and `repo` values against this list or pattern before using them to construct the URL.
3. If the values are not valid, log an error and return an empty array or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
